### PR TITLE
[Feature] Q 데이터셋 POST 요청 기능 구현

### DIFF
--- a/get_sami_answer.py
+++ b/get_sami_answer.py
@@ -1,0 +1,45 @@
+import json
+import requests
+from tqdm import tqdm
+import time
+
+input_dataset = input("Q데이터셋 입력(.json 제외): ")
+
+dataset = input_dataset + ".json"
+
+with open(dataset, "r", encoding="utf-8") as f:
+    questions = json.load(f)
+
+results = []
+
+for item in tqdm(questions):
+    question = item["question"]
+
+    try:
+        response = requests.post(
+            "http://localhost:8000/ask",
+            json={"question": question},
+            timeout=30
+        )
+        response.raise_for_status()
+
+        answer = response.json().get("answer", "")
+
+        results.append({
+            "answer": answer,
+        })
+
+    except Exception as e:
+        print(f"[오류] 질문: {question} / 오류: {e}")
+        results.append({
+            "answer": f"ERROR: {e}",
+        })
+
+    time.sleep(0.3)
+
+result = "sami_" + input_dataset.split("_q_dataset")[0] + "_a_dataset.json"
+
+print(result)
+
+with open(result, "w", encoding="utf-8") as f:
+    json.dump(results, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## 📌 개요
- Q 데이터셋 POST 요청 기능을 구현 완료했습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #3

## ✅ 변경 사항
- SAMI 챗봇에 Q 데이터셋 POST 요청과 이에 대한 SAMI의 답변 저장을 자동화합니다.

## 📝 상세 내용
- 사용법은 다음과 같습니다.
- SAMI-Backend 레포지토리의 코드를 실행
- SAMI-Performance 레포지토리의 get_sami_answer.py를 실행
- 사용자가 POST 요청할 Q 데이터셋 파일명을 입력합니다.(.json 제외)
  - 해당 파일은 json 파일만 가능합니다.
- 파일명을 입력하고나면 자동으로 Q 데이터셋의 Question들을 자동으로 POST 요청합니다.
- 모든 POST 요청이 끝나면 SAMI의 답변들이 하나의 json 파일로 저장됩니다.
