### PR TITLE
[Feature] 챗봇 데이터 평가 LLM 도입 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 .DS_Store
+.env
+similarity_prompt.txt

--- a/get_sentence_similarity_by_LLM.py
+++ b/get_sentence_similarity_by_LLM.py
@@ -1,0 +1,62 @@
+import os
+from openai import OpenAI
+from pathlib import Path
+import json
+from dotenv import load_dotenv
+from tqdm import tqdm
+
+WORK_DIR = Path(__file__).parent
+
+DATA_DIR = WORK_DIR / "data"
+OUTPUT_DIR = WORK_DIR / "output"
+Q_DATASET_DIR = OUTPUT_DIR / "q_dataset"
+A_DATASET_DIR = OUTPUT_DIR / "a_dataset"
+SIMILARITY_DIR = OUTPUT_DIR / "similarity"
+
+load_dotenv()
+api_key = os.getenv("OPEN_API_KEY")
+
+LLM = OpenAI(api_key=api_key)
+
+input_ground_truth_data = input("QnA의 A 데이터셋을 입력하세요(.json 제외, 예시: student_a_dataset): ")
+input_answer_data = input("SAMI의 A 데이터셋을 입력하세요(.json 제외, 예시: sami_student_a_dataset): ")
+
+ground_truth_dataset = input_ground_truth_data + ".json"
+answer_dataset = input_answer_data + ".json"
+
+with open(A_DATASET_DIR/ground_truth_dataset, "r", encoding="utf-8") as f:
+    ground_truth = json.load(f)
+
+with open(A_DATASET_DIR/answer_dataset, "r", encoding="utf-8") as f:
+    answers = json.load(f)
+
+results = []
+
+with open("similarity_prompt.txt", "r", encoding="utf-8") as f:
+    system_prompt = f.read()
+
+for ref_item, ans_item in tqdm(zip(ground_truth, answers), total=len(ground_truth), desc="문장 유사도 평가 중"):
+    ref = ref_item.get("answer", "")
+    ans = ans_item.get("answer", "")
+
+    messages = [{"role": "system", "content": system_prompt},
+                {"role": "user", "content": ref},
+                {"role": "user", "content": ans}]
+
+    completion = LLM.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=messages,
+    )
+
+    similarity = completion.choices[0].message.content
+
+    results.append({
+        "reference": ref,
+        "answer": ans,
+        "similarity": similarity
+    })
+
+result = input_ground_truth_data.split("_a")[0] + "_LLM_results.json"
+
+with open(SIMILARITY_DIR/result, "w", encoding="utf-8") as f:
+    json.dump(results, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## 📌 개요
- 챗봇 데이터 평가 LLM 도입 기능을 구현하였습니다.

## 🚀 관련 이슈
- 관련된 이슈 번호: #11 

## ✅ 변경 사항
- SAMI의 성능 평가 중 문장 유사도 점수를 LLM을 통해 평가하고 추출할 수 있도록 합니다.

## 📝 상세 내용
- get_sentence_similarity_by_LLM.py는 LLM을 통해 문장 유사도를 평가하고 유사도 점수를 추출합니다.
- 해당 코드 파일을 실행하면 다음과 같은 질문이 등장합니다.
  - QnA의 A 데이터셋을 입력하세요(.json 제외, 예시: student_a_dataset): 
  - SAMI의 A 데이터셋을 입력하세요(.json 제외, 예시: sami_student_a_dataset): 
- 각 질문에 맞게 파일을 입력하여 유사도 평가를 진행하면 다음과 같은 경로에 다음과 같은 형태로 파일이 저장됩니다.
  - 경로: output/similarity 
  - 형태: [데이터명]_LLM_results.json
- 해당 코드 파일을 이용하기 위해서는 사전에 공유했던 API KEY를 .env에 추가하여 진행하시면 됩니다.
- 추가적으로 similarity_prompt.txt 파일은 따로 공유할 예정입니다.
